### PR TITLE
fix: display the from name

### DIFF
--- a/model/v3/mail/send.go
+++ b/model/v3/mail/send.go
@@ -132,7 +132,7 @@ func sendMailWithSMTP(postRequest PostRequest)  (int, ErrorResponse) {
 	for _, personalizations := range postRequest.Personalizations {
 		e := email.NewEmail()
 
-		e.From = postRequest.From.Email
+		e.From = postRequest.From.Name + " <" + postRequest.From.Email + ">"
 
 		for _, to := range personalizations.To {
 			e.To = append(e.To, getEmailwithName(to))


### PR DESCRIPTION
```
curl --request POST \
  --url http://localhost:3030/v3/mail/send \
  --header 'Authorization: Bearer SG.xxxxx' \
  --header 'Content-Type: application/json' \
  --data '{"personalizations": [{ 
    "to": [{"email": "to@example.com", "name": "TO"}]}], 
    "from": {"email": "from@example.com", "name": "FROM"}, 
    "subject": "Test Subject", 
    "content": [{"type": "text/plain", "value": "Test Content"}] 
  }'
```

## before

![image](https://user-images.githubusercontent.com/6531126/151992772-56a5ce02-ad4c-41ba-affb-06e97526b484.png)

## after

![image](https://user-images.githubusercontent.com/6531126/151993216-57810af1-ae39-440b-aafb-d878693b5b6d.png)
