### PR TITLE
Fix Subject Validation

### DIFF
--- a/model/v3/mail/send.go
+++ b/model/v3/mail/send.go
@@ -20,7 +20,7 @@ import (
 type PostRequest struct {
 	Personalizations []struct {
 		Subject string `json:"subject"`
-		To      []struct {
+		To []struct {
 			Email string `json:"email"`
 			Name  string `json:"name"`
 		} `json:"to"`


### PR DESCRIPTION
the current sendgrid C# API and the current API examples place the subject field inside preferences, as opposed to top-level. This updates the model to account for that.